### PR TITLE
New fe_factory interface and initializations in TemplateBuilder

### DIFF
--- a/kipet/examples/Ex_1_ode_sim.py
+++ b/kipet/examples/Ex_1_ode_sim.py
@@ -32,9 +32,9 @@ if __name__ == "__main__":
     builder = TemplateBuilder()  
     
     #First we define the components present in the mixture
-    builder.add_mixture_component('A',1)
-    builder.add_mixture_component('B',0)
-    builder.add_mixture_component('C',0)
+    builder.add_mixture_component('A',0.1)
+    builder.add_mixture_component('B',0.0)
+    builder.add_mixture_component('C',0.0)
     
     #Following this we add the kinetic parameters
     builder.add_parameter('k1',2.0)

--- a/kipet/examples/Michaels_FESimulator.py
+++ b/kipet/examples/Michaels_FESimulator.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#  _________________________________________________________________________
+#
+#  Kipet: Kinetic parameter estimation toolkit
+#  Copyright (c) 2016 Eli Lilly.
+#  _________________________________________________________________________
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import sys
+from kipet.library.TemplateBuilder import *
+from kipet.library.PyomoSimulator import *
+from kipet.library.ParameterEstimator import *
+from kipet.library.VarianceEstimator import *
+from kipet.library.data_tools import *
+from kipet.library.fe_factory import *
+from kipet.library.FESimulator import *
+from pyomo.opt import *
+import pickle
+import os
+
+if __name__ == "__main__":
+
+    with_plots = True
+    if len(sys.argv)==2:
+        if int(sys.argv[1]):
+            with_plots = False
+            
+    #=========================================================================
+    #USER INPUT SECTION - REQUIRED MODEL BUILDING ACTIONS
+    #=========================================================================
+     
+    # create template model 
+    builder = TemplateBuilder()
+
+    # components
+    components = dict()
+    components['AH'] = 0.395555
+    components['B'] = 0.0351202
+    components['C'] = 0.0
+    components['BH+'] = 0.0
+    components['A-'] = 0.0
+    components['AC-'] = 0.0
+    components['P'] = 0.0
+
+    builder.add_mixture_component(components)
+
+    # add algebraics
+    algebraics = [0, 1, 2, 3, 4, 5]  # the indices of the rate rxns
+    # note the fifth component. Which basically works as an input
+
+    builder.add_algebraic_variable(algebraics)
+
+    params = dict()
+    params['k0'] = 49.7796
+    params['k1'] = 8.93156
+    params['k2'] = 1.31765
+    params['k3'] = 0.310870
+    params['k4'] = 3.87809
+
+    builder.add_parameter(params)
+
+    # add additional state variables
+    extra_states = dict()
+    extra_states['V'] = 0.0629418
+
+    builder.add_complementary_state_variable(extra_states)
+
+    # stoichiometric coefficients
+    gammas = dict()
+    gammas['AH'] = [-1, 0, 0, -1, 0]
+    gammas['B'] = [-1, 0, 0, 0, 1]
+    gammas['C'] = [0, -1, 1, 0, 0]
+    gammas['BH+'] = [1, 0, 0, 0, -1]
+    gammas['A-'] = [1, -1, 1, 1, 0]
+    gammas['AC-'] = [0, 1, -1, -1, -1]
+    gammas['P'] = [0, 0, 0, 1, 1]
+
+    def rule_algebraics(m, t):
+        r = list()
+        r.append(m.Y[t, 0] - m.P['k0'] * m.Z[t, 'AH'] * m.Z[t, 'B'])
+        r.append(m.Y[t, 1] - m.P['k1'] * m.Z[t, 'A-'] * m.Z[t, 'C'])
+        r.append(m.Y[t, 2] - m.P['k2'] * m.Z[t, 'AC-'])
+        r.append(m.Y[t, 3] - m.P['k3'] * m.Z[t, 'AC-'] * m.Z[t, 'AH'])
+        r.append(m.Y[t, 4] - m.P['k4'] * m.Z[t, 'AC-'] * m.Z[t, 'BH+'])
+        return r
+    #: there is no ae for Y[t,5] because step equn under rule_odes functions as the switch for the "C" equation
+
+    builder.set_algebraics_rule(rule_algebraics)
+
+
+    def rule_odes(m, t):
+        exprs = dict()
+        eta = 1e-2
+        #: @dthierry: This thingy is now framed in terms of `m.Y[t, 5]`
+        step = 0.5 * ((m.Y[t, 5] + 1) / ((m.Y[t, 5] + 1) ** 2 + eta ** 2) ** 0.5 + (210.0 - m.Y[t,5]) / ((210.0 - m.Y[t, 5]) ** 2 + eta ** 2) ** 0.5)
+        exprs['V'] = 7.27609e-05 * step
+        V = m.X[t, 'V']
+        # mass balances
+        for c in m.mixture_components:
+            exprs[c] = sum(gammas[c][j] * m.Y[t, j] for j in m.algebraics if j != 5) - exprs['V'] / V * m.Z[t, c]
+            if c == 'C':
+                exprs[c] += 0.02247311828 / (m.X[t, 'V'] * 210) * step
+        return exprs
+
+
+    builder.set_odes_rule(rule_odes)
+    dataDirectory = os.path.abspath(
+        os.path.join( os.path.dirname( os.path.abspath( inspect.getfile(
+            inspect.currentframe() ) ) ), 'data_sets'))
+    filename =  os.path.join(dataDirectory,'trimmed.csv')
+
+    D_frame = read_spectral_data_from_csv(filename)
+    meas_times = sorted(D_frame.index)
+
+    model = builder.create_pyomo_model(0, 600)
+
+    #=========================================================================
+    #USER INPUT SECTION - FE Factory
+    #=========================================================================
+     
+    # call FESimulator
+    # FESimulator re-constructs the current TemplateBuilder into fe_factory syntax
+    # there is no need to call PyomoSimulator any more as FESimulator is a child class 
+    sim = FESimulator(model)
+    
+    # defines the discrete points wanted in the concentration profile
+    sim.apply_discretization('dae.collocation', nfe=50, ncp=3, scheme='LAGRANGE-RADAU')
+
+    #Since the model cannot discriminate inputs from other algebraic elements, we still
+    #need to define the inputs as inputs_sub
+    inputs_sub = {}
+    inputs_sub['Y'] = [5]
+
+    #since these are inputs we need to fix this
+    for key in sim.model.time.value:
+        sim.model.Y[key, 5].set_value(key)
+        sim.model.Y[key, 5].fix()
+
+    #this will allow for the fe_factory to run the element by element march forward along 
+    #the elements and also automatically initialize the PyomoSimulator model, allowing
+    #for the use of the run_sim() function as before. We only need to provide the inputs 
+    #to this function as an argument dictionary
+    init = sim.call_fe_factory(inputs_sub)
+    #=========================================================================
+    #USER INPUT SECTION - SIMULATION
+    #=========================================================================
+     
+    #: now the final run, just as before
+    # simulate
+    options = {}
+    results = sim.run_sim('ipopt',
+                          tee=True,
+                          solver_opts=options)
+
+    if with_plots:
+        # display concentration results    
+        results.Z.plot.line(legend=True)
+        plt.xlabel("time (s)")
+        plt.ylabel("Concentration (mol/L)")
+        plt.title("Concentration Profile")
+        plt.show()
+    
+        #results.Y[0].plot.line()
+        results.Y[1].plot.line(legend=True)
+        results.Y[2].plot.line(legend=True)
+        results.Y[3].plot.line(legend=True)
+        results.Y[4].plot.line(legend=True)
+        plt.xlabel("time (s)")
+        plt.ylabel("rxn rates (mol/L*s)")
+        plt.title("Rates of rxn")
+        plt.show()
+
+        results.X.plot.line(legend=True)
+        plt.xlabel("time (s)")
+        plt.ylabel("Volume (L)")
+        plt.title("total volume")
+        plt.show()
+    #D_frame.plot.line(legend=False)
+    #plt.show()
+    
+    #plot_spectral_data(D_frame,dimension='3D')
+    
+    #results.Z.to_csv("initialization.csv")

--- a/kipet/examples/aspirin_FESimulator_try.py
+++ b/kipet/examples/aspirin_FESimulator_try.py
@@ -1,0 +1,354 @@
+#  _________________________________________________________________________
+#
+#  Kipet: Kinetic parameter estimation toolkit
+#  Copyright (c) 2016 Eli Lilly.
+#  _________________________________________________________________________
+
+# Aspirin Example
+#
+#		\frac{dZ_aa}{dt} = -r_0-r_1-r_3-\frac{\dot{v}}{V}*Z_aa
+# 	    	\frac{dZ_ha}{dt} = r_0+r_1+r_2+2r_3-\frac{\dot{v}}{V}*Z_ha
+#        \frac{dZ_asaa}{dt} = r_1-r_2-\frac{\dot{v}}{V}*Z_asaa
+#        \frac{dZ_h2o}{dt} = -r_2-r_3+\frac{f}{V}*C_h2o^in-\frac{\dot{v}}{V}*Z_asaa
+
+#        \frac{dm_{sa}}{dt} = -M_{sa}*V*r_d
+#        \frac{dm_{asa}}{dt} = -M_{asa}*V*r_c
+#        \frac{dV}{dt} = V*\sum_i^{ns}\upsilon_i*(\sum_j^{6}\gamma_i*r_j+\epsilon_i*\frac{f}{V}*C_h2o^in)
+
+#        r_0 = k_0*Z_sa*Z_aa
+#        r_1 = k_1*Z_asa*Z_aa
+#        r_2 = k_2*Z_asaa*Z_h2o
+#        r_3 = k_3*Z_aa*Z_h2o
+#        r_d = k_d*(Z_sa^{sat}-Z_sa)^d
+#        r_c = k_c*(max(Z_asa-Z_sa^{sat}))^c
+
+from kipet.library.TemplateBuilder import *
+from kipet.library.PyomoSimulator import *
+from kipet.library.ParameterEstimator import *
+from kipet.library.VarianceEstimator import *
+from kipet.library.data_tools import *
+from kipet.library.fe_factory import *
+from kipet.library.FESimulator import *
+from pyomo.core.kernel.expr import exp
+import matplotlib.pyplot as plt
+import numpy as np
+import sys
+import os
+import pprint
+
+if __name__ == "__main__":
+    
+    with_plots = True
+    if len(sys.argv)==2:
+        if int(sys.argv[1]):
+            with_plots = False
+    
+    #=========================================================================
+    #USER INPUT SECTION - REQUIRED MODEL BUILDING ACTIONS
+    #=========================================================================
+ 
+    dataDirectory = os.path.abspath(
+        os.path.join( os.path.dirname( os.path.abspath( inspect.getfile(
+            inspect.currentframe() ) ) ), 'data_sets'))
+    traj =  os.path.join(dataDirectory,'extra_states.txt')
+
+    dataDirectory = os.path.abspath(
+        os.path.join( os.path.dirname( os.path.abspath( inspect.getfile(
+            inspect.currentframe() ) ) ), 'data_sets'))
+    conc =  os.path.join(dataDirectory,'concentrations.txt')    
+    
+    fixed_traj = read_absorption_data_from_txt(traj)
+    C = read_absorption_data_from_txt(conc)
+    
+
+    meas_times=sorted(C.index)
+    print(meas_times)
+    # How many measurement times are there
+    nfe_x = len(meas_times)
+    print(nfe_x)
+    # create template model 
+    builder = TemplateBuilder()    
+
+
+
+    # components
+    components = dict()
+    components['SA'] = 1.0714               # Salicitilc acid
+    components['AA'] = 9.3828               # Acetic anhydride
+    components['ASA'] = 0.0177              # Acetylsalicylic acid
+    components['HA'] = 0.0177               # Acetic acid
+    components['ASAA'] = 0.000015           # Acetylsalicylic anhydride
+    components['H2O'] = 0.0                 # water
+
+    builder.add_mixture_component(components)
+
+    # add parameters
+    params = dict()
+    params['k0'] = 0.0360309
+    params['k1'] = 0.1596062
+    params['k2'] = 6.8032345
+    params['k3'] = 1.8028763
+    params['kd'] = 7.1108682
+    params['kc'] = 0.7566864
+    params['Csa'] = 2.06269996
+
+    builder.add_parameter(params)
+
+    # add additional state variables
+    extra_states = dict()
+    extra_states['V'] = 0.0202
+    extra_states['Masa'] = 0.0
+    extra_states['Msa'] = 9.537
+    
+    builder.add_complementary_state_variable(extra_states)
+
+    algebraics = ['f','Csat','r0','r1','r2','r3','r4','r5','v_sum']
+
+    builder.add_algebraic_variable(algebraics)
+
+    #remove the f and Csat algebraic variables and fix them as time-dependent parameters
+    #now we fix the non-variable for the fe_factory, f and Csat
+
+    gammas = dict()
+    gammas['SA']=    [-1, 0, 0, 0, 1, 0]
+    gammas['AA']=    [-1,-1, 0,-1, 0, 0]
+    gammas['ASA']=   [ 1,-1, 1, 0, 0,-1]
+    gammas['HA']=    [ 1, 1, 1, 2, 0, 0]
+    gammas['ASAA']=  [ 0, 1,-1, 0, 0, 0]
+    gammas['H2O']=   [ 0, 0,-1,-1, 0, 0]
+
+
+    epsilon = dict()
+    epsilon['SA']= 0.0
+    epsilon['AA']= 0.0
+    epsilon['ASA']= 0.0
+    epsilon['HA']= 0.0
+    epsilon['ASAA']= 0.0
+    epsilon['H2O']= 1.0
+    
+    partial_vol = dict()
+    partial_vol['SA'] = 0.0952552311614
+    partial_vol['AA'] = 0.101672206869
+    partial_vol['ASA'] = 0.132335206093
+    partial_vol['HA'] = 0.060320218688
+    partial_vol['ASAA'] = 0.186550717015
+    partial_vol['H2O'] = 0.0883603912169
+    
+    def rule_algebraics(m,t):
+        r = list()
+        r.append(m.Y[t,'r0']-m.P['k0']*m.Z[t,'SA']*m.Z[t,'AA'])
+        r.append(m.Y[t,'r1']-m.P['k1']*m.Z[t,'ASA']*m.Z[t,'AA'])
+        r.append(m.Y[t,'r2']-m.P['k2']*m.Z[t,'ASAA']*m.Z[t,'H2O'])
+        r.append(m.Y[t,'r3']-m.P['k3']*m.Z[t,'AA']*m.Z[t,'H2O'])
+
+        # dissolution rate
+        step = 1.0/(1.0+exp(-m.X[t,'Msa']/1e-4))
+        rd = m.P['kd']*(m.P['Csa']-m.Z[t,'SA']+1e-6)**1.90*step
+        r.append(m.Y[t,'r4']-rd)
+        #r.append(m.Y[t,'r4'])
+        
+        # crystalization rate
+        diff = m.Z[t,'ASA'] - m.Y[t,'Csat']
+        rc = 0.3950206559*m.P['kc']*(diff+((diff)**2+1e-6)**0.5)**1.34
+        r.append(m.Y[t,'r5']-rc)
+
+        Cin = 39.1
+        v_sum = 0.0
+        V = m.X[t,'V']
+        f = m.Y[t,'f']
+        for c in m.mixture_components:
+            v_sum += partial_vol[c]*(sum(gammas[c][j]*m.Y[t,'r{}'.format(j)] for j in range(6))+ epsilon[c]*f/V*Cin)
+        r.append(m.Y[t,'v_sum']-v_sum)
+
+        return r
+
+    builder.set_algebraics_rule(rule_algebraics)
+    
+    def rule_odes(m,t):
+        exprs = dict()
+
+        V = m.X[t,'V']
+        f = m.Y[t,'f']
+        Cin = 41.4
+        # volume balance
+        vol_sum = 0.0
+        for c in m.mixture_components:
+            vol_sum += partial_vol[c]*(sum(gammas[c][j]*m.Y[t,'r{}'.format(j)] for j in range(6))+ epsilon[c]*f/V*Cin)
+        exprs['V'] = V*m.Y[t,'v_sum']
+
+        # mass balances
+        for c in m.mixture_components:
+            exprs[c] = sum(gammas[c][j]*m.Y[t,'r{}'.format(j)] for j in range(6))+ epsilon[c]*f/V*Cin - m.Y[t,'v_sum']*m.Z[t,c]
+
+        exprs['Masa'] = 180.157*V*m.Y[t,'r5']
+        exprs['Msa'] = -138.121*V*m.Y[t,'r4']
+        return exprs
+
+
+
+
+    builder.set_odes_rule(rule_odes)
+
+    model = builder.create_pyomo_model(0.0,210.5257)    
+ #=========================================================================
+    #USER INPUT SECTION - FE Factory
+    #=========================================================================
+     
+    fe_x_list = [ii for ii in range(1, nfe_x + 1)]
+    model.fe_x_i = Set(initialize=fe_x_list)
+    
+    sim = FESimulator(model)
+    
+    # defines the discrete points wanted in the concentration profile
+    sim.apply_discretization('dae.collocation', nfe=(nfe_x), ncp=3, scheme='LAGRANGE-RADAU')
+    fe_l = sim.model.time.get_finite_elements()
+    fe_list = [fe_l[i + 1] - fe_l[i] for i in range(0, len(fe_l) - 1)]
+    nfe = len(fe_list)  #: Create a list with the step-size
+    print(nfe)
+    #sys.exit()
+
+    #sim.fix_from_trajectory('X','V',fixed_traj)
+
+    #: we now need to explicitly tell the initial conditions and parameter values
+    #param_name = "P"
+    #param_dict = {}
+    #param_dict["P", "k0"] = 0.0360309
+    #param_dict["P", "k1"] = 0.1596062
+    #param_dict["P", "k2"] = 6.8032345
+    #param_dict["P", "k3"] = 1.8028763
+    #param_dict["P", "kd"] = 7.1108682
+    #param_dict["P", "kc"] = 0.7566864
+    #param_dict["P", "Csa"] = 2.06269996
+
+    #ics_ = dict()
+    #ics_['Z', 'SA'] = 1.0714
+    #ics_['Z', 'AA'] = 9.3828 
+    #ics_['Z', 'ASA'] = 0.0177
+    #ics_['Z', 'HA'] = 0.0177 
+    #ics_['Z', 'ASAA'] =0.000015
+    #ics_['Z', 'H2O'] = 0.0
+
+    #ics_['X', 'V'] = 0.0202
+    #ics_['X', 'Masa'] = 0.0
+    #ics_['X', 'Msa'] = 9.537
+    
+        
+    #inputs_sub = {}
+    
+    inputs_sub['Y'] = ['f', 'Csat']
+
+    sim.fix_from_trajectory('Y','Csat',fixed_traj)
+    sim.fix_from_trajectory('Y','f',fixed_traj)
+    # for t in sim.model.time:
+    #     v = value(sim.model.Y[t, 'f'])
+    #     print(t, v)
+    #: define the values for our simulation
+    #for key in sim.model.time.value:
+    #    sim.model.Y[key,'f'].set_value(key)
+    #    sim.model.Y[key,'f'].fix()  #if you don't fix this, fe_factory is will not work complain.
+    #    sim.model.Y[key,'Csat'].set_value(key)
+    #    sim.model.Y[key,'Csat'].fix() 
+    #
+
+
+    #init = fe_initialize(sim.model, mod,
+    #                     init_con="init_conditions_c",
+    #                     param_name=param_name,
+    #                     param_values=param_dict,
+    #                     inputs_sub=inputs_sub)
+    
+    #init.load_initial_conditions(init_cond=ics_)
+   
+    #init.run()
+    init = sim.call_fe_factory(inputs_sub)
+    #=========================================================================
+    #USER INPUT SECTION - SIMULATION
+    #=========================================================================
+  
+    # sim = PyomoSimulator(model)
+    # defines the discrete points wanted in the concentration profile
+    # sim.apply_discretization('dae.collocation',nfe=100,ncp=3,scheme='LAGRANGE-RADAU')
+    
+    # good initialization
+
+#    filename_initZ = os.path.join(dataDirectory, 'init_Z.csv')#Use absolute paths
+#    initialization = pd.read_csv(filename_initZ,index_col=0)
+#    sim.initialize_from_trajectory('Z',initialization)
+#    filename_initX = os.path.join(dataDirectory, 'init_X.csv')#Use absolute paths
+#    initialization = pd.read_csv(filename_initX,index_col=0)
+#    sim.initialize_from_trajectory('X',initialization)
+#    filename_initY = os.path.join(dataDirectory, 'init_Y.csv')#Use absolute paths
+#    initialization = pd.read_csv(filename_initY,index_col=0)
+#    sim.initialize_from_trajectory('Y',initialization)
+            
+    sim.fix_from_trajectory('Y','Csat',fixed_traj)
+    sim.fix_from_trajectory('Y','f',fixed_traj)
+
+    for i in sim.model.X.itervalues():
+        idx = i.index()
+        if idx[1] in ['Msa', 'Masa']:
+            i.setlb(-0.05)
+        else:
+            i.setlb(0)
+
+    for i in sim.model.Z.itervalues():
+        i.setlb(0)
+        idx = i.index()
+        if idx[1] == 'SA':
+            i.setub(2.06269996)
+
+
+    options = {'halt_on_ampl_error' :'yes',
+               'bound_push': 1e-06,
+               'print_user_options': 'yes',
+               "max_iter": 1}
+    results = sim.run_sim('ipopt',
+                          tee=True,
+                          solver_opts=options)
+    if with_plots:
+        # display concentration results    
+        results.Z.plot.line(legend=True)
+        plt.xlabel("time (s)")
+        plt.ylabel("Concentration (mol/L)")
+        plt.title("Concentration Profile")
+
+        C.plot()
+        
+        plt.figure()
+        
+        results.Y['Csat'].plot.line()
+        plt.plot(fixed_traj['Csat'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("Csat")
+        plt.title("Saturation Concentration")
+        
+        plt.figure()
+        
+        results.X['V'].plot.line()
+        plt.plot(fixed_traj['V'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("volumne (L)")
+        plt.title("Volume Profile")
+
+        plt.figure()
+        
+        results.X['Msa'].plot.line()
+        plt.plot(fixed_traj['Msa'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("m_dot (g)")
+        plt.title("Msa Profile")
+
+        plt.figure()
+        results.Y['f'].plot.line()
+        plt.xlabel("time (s)")
+        plt.ylabel("flow (K)")
+        plt.title("Inlet flow Profile")
+
+        plt.figure()
+        results.X['Masa'].plot.line()
+        plt.plot(fixed_traj['Masa'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("m_dot (g)")
+        plt.title("Masa Profile")
+        
+plt.show()

--- a/kipet/examples/aspirin_sim_fe_factory_new_try.py
+++ b/kipet/examples/aspirin_sim_fe_factory_new_try.py
@@ -1,0 +1,354 @@
+#  _________________________________________________________________________
+#
+#  Kipet: Kinetic parameter estimation toolkit
+#  Copyright (c) 2016 Eli Lilly.
+#  _________________________________________________________________________
+
+# Aspirin Example
+#
+#		\frac{dZ_aa}{dt} = -r_0-r_1-r_3-\frac{\dot{v}}{V}*Z_aa
+# 	    	\frac{dZ_ha}{dt} = r_0+r_1+r_2+2r_3-\frac{\dot{v}}{V}*Z_ha
+#        \frac{dZ_asaa}{dt} = r_1-r_2-\frac{\dot{v}}{V}*Z_asaa
+#        \frac{dZ_h2o}{dt} = -r_2-r_3+\frac{f}{V}*C_h2o^in-\frac{\dot{v}}{V}*Z_asaa
+
+#        \frac{dm_{sa}}{dt} = -M_{sa}*V*r_d
+#        \frac{dm_{asa}}{dt} = -M_{asa}*V*r_c
+#        \frac{dV}{dt} = V*\sum_i^{ns}\upsilon_i*(\sum_j^{6}\gamma_i*r_j+\epsilon_i*\frac{f}{V}*C_h2o^in)
+
+#        r_0 = k_0*Z_sa*Z_aa
+#        r_1 = k_1*Z_asa*Z_aa
+#        r_2 = k_2*Z_asaa*Z_h2o
+#        r_3 = k_3*Z_aa*Z_h2o
+#        r_d = k_d*(Z_sa^{sat}-Z_sa)^d
+#        r_c = k_c*(max(Z_asa-Z_sa^{sat}))^c
+
+from kipet.library.TemplateBuilder import *
+from kipet.library.PyomoSimulator import *
+from kipet.library.ParameterEstimator import *
+from kipet.library.VarianceEstimator import *
+from kipet.library.data_tools import *
+from kipet.library.fe_factory import *
+from pyomo.core.kernel.expr import exp
+import matplotlib.pyplot as plt
+import numpy as np
+import sys
+import os
+import pprint
+
+if __name__ == "__main__":
+    
+    with_plots = True
+    if len(sys.argv)==2:
+        if int(sys.argv[1]):
+            with_plots = False
+    
+    #=========================================================================
+    #USER INPUT SECTION - REQUIRED MODEL BUILDING ACTIONS
+    #=========================================================================
+ 
+    dataDirectory = os.path.abspath(
+        os.path.join( os.path.dirname( os.path.abspath( inspect.getfile(
+            inspect.currentframe() ) ) ), 'data_sets'))
+    traj =  os.path.join(dataDirectory,'extra_states.txt')
+
+    dataDirectory = os.path.abspath(
+        os.path.join( os.path.dirname( os.path.abspath( inspect.getfile(
+            inspect.currentframe() ) ) ), 'data_sets'))
+    conc =  os.path.join(dataDirectory,'concentrations.txt')    
+    
+    fixed_traj = read_absorption_data_from_txt(traj)
+    C = read_absorption_data_from_txt(conc)
+    
+
+    meas_times=sorted(C.index)
+    print(meas_times)
+    # How many measurement times are there
+    nfe_x = len(meas_times)
+    print(nfe_x)
+    # create template model 
+    builder = TemplateBuilder()    
+
+
+
+    # components
+    components = dict()
+    components['SA'] = 1.0714               # Salicitilc acid
+    components['AA'] = 9.3828               # Acetic anhydride
+    components['ASA'] = 0.0177              # Acetylsalicylic acid
+    components['HA'] = 0.0177               # Acetic acid
+    components['ASAA'] = 0.000015           # Acetylsalicylic anhydride
+    components['H2O'] = 0.0                 # water
+
+    builder.add_mixture_component(components)
+
+    # add parameters
+    params = dict()
+    params['k0'] = 0.0360309
+    params['k1'] = 0.1596062
+    params['k2'] = 6.8032345
+    params['k3'] = 1.8028763
+    params['kd'] = 7.1108682
+    params['kc'] = 0.7566864
+    params['Csa'] = 2.06269996
+
+    builder.add_parameter(params)
+
+    # add additional state variables
+    extra_states = dict()
+    extra_states['V'] = 0.0202
+    extra_states['Masa'] = 0.0
+    extra_states['Msa'] = 9.537
+    
+    builder.add_complementary_state_variable(extra_states)
+
+    algebraics = ['f','Csat','r0','r1','r2','r3','r4','r5','v_sum']
+
+    builder.add_algebraic_variable(algebraics)
+
+    #remove the f and Csat algebraic variables and fix them as time-dependent parameters
+    #now we fix the non-variable for the fe_factory, f and Csat
+
+    gammas = dict()
+    gammas['SA']=    [-1, 0, 0, 0, 1, 0]
+    gammas['AA']=    [-1,-1, 0,-1, 0, 0]
+    gammas['ASA']=   [ 1,-1, 1, 0, 0,-1]
+    gammas['HA']=    [ 1, 1, 1, 2, 0, 0]
+    gammas['ASAA']=  [ 0, 1,-1, 0, 0, 0]
+    gammas['H2O']=   [ 0, 0,-1,-1, 0, 0]
+
+
+    epsilon = dict()
+    epsilon['SA']= 0.0
+    epsilon['AA']= 0.0
+    epsilon['ASA']= 0.0
+    epsilon['HA']= 0.0
+    epsilon['ASAA']= 0.0
+    epsilon['H2O']= 1.0
+    
+    partial_vol = dict()
+    partial_vol['SA'] = 0.0952552311614
+    partial_vol['AA'] = 0.101672206869
+    partial_vol['ASA'] = 0.132335206093
+    partial_vol['HA'] = 0.060320218688
+    partial_vol['ASAA'] = 0.186550717015
+    partial_vol['H2O'] = 0.0883603912169
+    
+    def rule_algebraics(m,t):
+        r = list()
+        r.append(m.Y[t,'r0']-m.P['k0']*m.Z[t,'SA']*m.Z[t,'AA'])
+        r.append(m.Y[t,'r1']-m.P['k1']*m.Z[t,'ASA']*m.Z[t,'AA'])
+        r.append(m.Y[t,'r2']-m.P['k2']*m.Z[t,'ASAA']*m.Z[t,'H2O'])
+        r.append(m.Y[t,'r3']-m.P['k3']*m.Z[t,'AA']*m.Z[t,'H2O'])
+
+        # dissolution rate
+        step = 1.0/(1.0+exp(-m.X[t,'Msa']/1e-4))
+        rd = m.P['kd']*(m.P['Csa']-m.Z[t,'SA']+1e-6)**1.90*step
+        r.append(m.Y[t,'r4']-rd)
+        #r.append(m.Y[t,'r4'])
+        
+        # crystalization rate
+        diff = m.Z[t,'ASA'] - m.Y[t,'Csat']
+        rc = 0.3950206559*m.P['kc']*(diff+((diff)**2+1e-6)**0.5)**1.34
+        r.append(m.Y[t,'r5']-rc)
+
+        Cin = 39.1
+        v_sum = 0.0
+        V = m.X[t,'V']
+        f = m.Y[t,'f']
+        for c in m.mixture_components:
+            v_sum += partial_vol[c]*(sum(gammas[c][j]*m.Y[t,'r{}'.format(j)] for j in range(6))+ epsilon[c]*f/V*Cin)
+        r.append(m.Y[t,'v_sum']-v_sum)
+
+        return r
+
+    builder.set_algebraics_rule(rule_algebraics)
+    
+    def rule_odes(m,t):
+        exprs = dict()
+
+        V = m.X[t,'V']
+        f = m.Y[t,'f']
+        Cin = 41.4
+        # volume balance
+        vol_sum = 0.0
+        for c in m.mixture_components:
+            vol_sum += partial_vol[c]*(sum(gammas[c][j]*m.Y[t,'r{}'.format(j)] for j in range(6))+ epsilon[c]*f/V*Cin)
+        exprs['V'] = V*m.Y[t,'v_sum']
+
+        # mass balances
+        for c in m.mixture_components:
+            exprs[c] = sum(gammas[c][j]*m.Y[t,'r{}'.format(j)] for j in range(6))+ epsilon[c]*f/V*Cin - m.Y[t,'v_sum']*m.Z[t,c]
+
+        exprs['Masa'] = 180.157*V*m.Y[t,'r5']
+        exprs['Msa'] = -138.121*V*m.Y[t,'r4']
+        return exprs
+
+
+
+
+    builder.set_odes_rule(rule_odes)
+
+    model = builder.create_pyomo_model(0.0,210.5257)    
+ #=========================================================================
+    #USER INPUT SECTION - FE Factory
+    #=========================================================================
+     
+    fe_x_list = [ii for ii in range(1, nfe_x + 1)]
+    model.fe_x_i = Set(initialize=fe_x_list)
+    
+    sim = PyomoSimulator(model)
+    mod = sim.model.clone()
+    
+    # defines the discrete points wanted in the concentration profile
+    sim.apply_discretization('dae.collocation', nfe=(nfe_x+1), ncp=3, scheme='LAGRANGE-RADAU')
+    fe_l = sim.model.time.get_finite_elements()
+    fe_list = [fe_l[i + 1] - fe_l[i] for i in range(0, len(fe_l) - 1)]
+    nfe = len(fe_list)  #: Create a list with the step-size
+    print(nfe)
+    #sys.exit()
+
+    #sim.fix_from_trajectory('X','V',fixed_traj)
+
+    #: we now need to explicitly tell the initial conditions and parameter values
+    param_name = "P"
+    param_dict = {}
+    param_dict["P", "k0"] = 0.0360309
+    param_dict["P", "k1"] = 0.1596062
+    param_dict["P", "k2"] = 6.8032345
+    param_dict["P", "k3"] = 1.8028763
+    param_dict["P", "kd"] = 7.1108682
+    param_dict["P", "kc"] = 0.7566864
+    param_dict["P", "Csa"] = 2.06269996
+
+    ics_ = dict()
+    ics_['Z', 'SA'] = 1.0714
+    ics_['Z', 'AA'] = 9.3828 
+    ics_['Z', 'ASA'] = 0.0177
+    ics_['Z', 'HA'] = 0.0177 
+    ics_['Z', 'ASAA'] =0.000015
+    ics_['Z', 'H2O'] = 0.0
+
+    ics_['X', 'V'] = 0.0202
+    ics_['X', 'Masa'] = 0.0
+    ics_['X', 'Msa'] = 9.537
+    
+        
+    inputs_sub = {}
+    
+    inputs_sub['Y'] = ['f', 'Csat']
+
+    sim.fix_from_trajectory('Y','Csat',fixed_traj)
+    sim.fix_from_trajectory('Y','f',fixed_traj)
+    # for t in sim.model.time:
+    #     v = value(sim.model.Y[t, 'f'])
+    #     print(t, v)
+    #: define the values for our simulation
+#    for key in sim.model.time.value:
+#        sim.model.Y[key,'f'].set_value(key)
+#        sim.model.Y[key,'f'].fix()  #if you don't fix this, fe_factory is will not work complain.
+     #   sim.model.Y[key,'Csat'].set_value(key)
+     #   sim.model.Y[key,'Csat'].fix() 
+    #
+
+
+    init = fe_initialize(sim.model, mod,
+                         init_con="init_conditions_c",
+                         param_name=param_name,
+                         param_values=param_dict,
+                         inputs_sub=inputs_sub)
+    
+    init.load_initial_conditions(init_cond=ics_)
+   
+    init.run()
+
+    #=========================================================================
+    #USER INPUT SECTION - SIMULATION
+    #=========================================================================
+  
+    # sim = PyomoSimulator(model)
+    # defines the discrete points wanted in the concentration profile
+    # sim.apply_discretization('dae.collocation',nfe=100,ncp=3,scheme='LAGRANGE-RADAU')
+    
+    # good initialization
+
+#    filename_initZ = os.path.join(dataDirectory, 'init_Z.csv')#Use absolute paths
+#    initialization = pd.read_csv(filename_initZ,index_col=0)
+#    sim.initialize_from_trajectory('Z',initialization)
+#    filename_initX = os.path.join(dataDirectory, 'init_X.csv')#Use absolute paths
+#    initialization = pd.read_csv(filename_initX,index_col=0)
+#    sim.initialize_from_trajectory('X',initialization)
+#    filename_initY = os.path.join(dataDirectory, 'init_Y.csv')#Use absolute paths
+#    initialization = pd.read_csv(filename_initY,index_col=0)
+#    sim.initialize_from_trajectory('Y',initialization)
+            
+#    sim.fix_from_trajectory('Y','Csat',fixed_traj)
+#    sim.fix_from_trajectory('Y','f',fixed_traj)
+
+    for i in sim.model.X.itervalues():
+        idx = i.index()
+        if idx[1] in ['Msa', 'Masa']:
+            i.setlb(-0.05)
+        else:
+            i.setlb(0)
+
+    for i in sim.model.Z.itervalues():
+        i.setlb(0)
+        idx = i.index()
+        if idx[1] == 'SA':
+            i.setub(2.06269996)
+
+
+    options = {'halt_on_ampl_error' :'yes',
+               'bound_push': 1e-06,
+               'print_user_options': 'yes',
+               "max_iter": 1}
+    results = sim.run_sim('ipopt',
+                          tee=True,
+                          solver_opts=options)
+    if with_plots:
+        # display concentration results    
+        results.Z.plot.line(legend=True)
+        plt.xlabel("time (s)")
+        plt.ylabel("Concentration (mol/L)")
+        plt.title("Concentration Profile")
+
+        C.plot()
+        
+        plt.figure()
+        
+        results.Y['Csat'].plot.line()
+        plt.plot(fixed_traj['Csat'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("Csat")
+        plt.title("Saturation Concentration")
+        
+        plt.figure()
+        
+        results.X['V'].plot.line()
+        plt.plot(fixed_traj['V'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("volumne (L)")
+        plt.title("Volume Profile")
+
+        plt.figure()
+        
+        results.X['Msa'].plot.line()
+        plt.plot(fixed_traj['Msa'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("m_dot (g)")
+        plt.title("Msa Profile")
+
+        plt.figure()
+        results.Y['f'].plot.line()
+        plt.xlabel("time (s)")
+        plt.ylabel("flow (K)")
+        plt.title("Inlet flow Profile")
+
+        plt.figure()
+        results.X['Masa'].plot.line()
+        plt.plot(fixed_traj['Masa'],'*')
+        plt.xlabel("time (s)")
+        plt.ylabel("m_dot (g)")
+        plt.title("Masa Profile")
+        
+plt.show()

--- a/kipet/library/FESimulator.py
+++ b/kipet/library/FESimulator.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+from pyomo.environ import *
+from pyomo.dae import *
+from kipet.library.ResultsObject import *
+from kipet.library.Simulator import *
+from kipet.library.PyomoSimulator import *
+from kipet.library.fe_factory import *
+import warnings
+import six
+import sys
+
+__author__ = 'Michael Short'  #: July 2018
+
+class FESimulator(PyomoSimulator):
+    def __init__(self, model):
+        """
+            FESimulator class:
+    
+                This class is just an interface that allows the user of Kipet to easily implement the more general 
+                fe_factory class designed by David M. Thierry without having to re-write the model to fit those
+                arguments. It takes in a standard Kipet/Pyomo model, rewrites it and calls fe_factory.
+                More information on fe_factory is included in that class description.
+    
+                Args:
+                    model (ConcreteModel): The original Pyomo model created in the Kipet script
+        """
+        super(FESimulator, self).__init__(model)
+        self.p_sim =  PyomoSimulator(model)
+        self.c_sim = self.p_sim.model.clone()
+        self.param_dict = {}
+        self.param_name = "P"
+
+        # check all parameters are fixed before simulating
+        for p_sim_data in six.itervalues(self.p_sim.model.P):
+            if not p_sim_data.fixed:
+                raise RuntimeError('For simulation fix all parameters. Parameter {} is unfixed'.format(p_sim_data.cname()))
+
+        #Build the parameter dictionary in the format that fe_factory uses    
+        for k,v in six.iteritems(self.p_sim.model.P):
+            self.param_dict["P",k] = v.value
+
+        #Build the initial condition dictionary in the format that fe_factory uses
+        self.ics_ = {} 
+
+        for t, k in six.iteritems(self.p_sim.model.Z):
+            st = self.p_sim.model.start_time
+            if t[0] == st:
+                self.ics_['Z', t[1]] = k.value
+                
+        #Now to set the additional state values
+        for t, v in six.iteritems(self.p_sim.model.X):
+            if t[0] == st:
+                self.ics_['X',t[1]] = v.value
+
+    def call_fe_factory(self, inputs_sub=None):
+        """
+        call_fe_factory:
+    
+                This function applies all the inputs necessary for fe_factory to work, using Kipet syntax.
+    
+                Args:
+                    none
+        """
+        self.inputs_sub = None
+        self.inputs_sub=inputs_sub
+        
+        init = fe_initialize(self.p_sim.model, self.c_sim,
+                         init_con="init_conditions_c",
+                         param_name=self.param_name,
+                         param_values=self.param_dict,
+                         inputs_sub=self.inputs_sub)
+    
+        init.load_initial_conditions(init_cond=self.ics_)
+   
+        init.run()

--- a/kipet/library/PyomoSimulator.py
+++ b/kipet/library/PyomoSimulator.py
@@ -101,7 +101,7 @@ class PyomoSimulator(Simulator):
         z_init_panel = pd.DataFrame(data=z_array,
                                  columns=self._mixture_components,
                                  index=self._times)
-
+        
         c_init = []
         for t in self._meas_times:
             for k in self._mixture_components:

--- a/kipet/library/__init__.py
+++ b/kipet/library/__init__.py
@@ -17,8 +17,8 @@ except ImportError:
 if found_casadi: 
     __all__ = ['CasadiModel','TemplateBuilder','BaseAbstractModel','CasadiSimulator',
                'data_tools','fe_factory','Optimizer','ParameterEstimator','PyomoSimulator',
-               'ResultsObject','Simulator','VarianceEstimator'] 
+               'ResultsObject','Simulator','VarianceEstimator','FESimulator'] 
 else: 
     __all__ = ['TemplateBuilder','BaseAbstractModel',
                'data_tools','fe_factory','Optimizer','ParameterEstimator',
-               'PyomoSimulator','ResultsObject','Simulator','VarianceEstimator']  
+               'PyomoSimulator','ResultsObject','Simulator','VarianceEstimator','FESimulator']  


### PR DESCRIPTION
This new branch contains a new way to call fe_factory through the use of a new module "FESimulator" which just constructs the problem for fe_factory so that the user no longer needs to re-enter the problem for fe_factory. The new method is demonstrated in 'Michaels_FESimulator.py'. Currently it is not working for the aspirin_fe_factory problems, but that is the case for the other branches as well. Both examples fail on the second finite element.

During the making of this wrapper function I encountered the issue with the inits being set to 1 and then fixed this through forcing the initializations in the TemplateBuilder to come from the initial_conditions inputted by the user.