### PR TITLE
Fix bugs in KIPET when using Pyomo 5.6.8

### DIFF
--- a/kipet/library/ResultsObject.py
+++ b/kipet/library/ResultsObject.py
@@ -84,11 +84,20 @@ class ResultsObject(object):
                     d = v.get_values()
                     keys = d.keys()
                     if keys:
-                        split_keys = v._implicit_subsets
-                        # split_keys = zip(*keys)
-                        # print(split_keys)
-                        first_set = set(split_keys[0])
-                        second_set = set(split_keys[1])
+                        # split_keys = v._implicit_subsets
+                        # print(v._implicit_subsets)
+                        # # split_keys = zip(*keys)
+                        # # print(split_keys)
+                        # first_set = set(split_keys[0])
+                        # second_set = set(split_keys[1])
+                        first_key_list = []
+                        second_key_list = []
+                        for i in list(keys):
+                            first_key_list.append(i[0])
+                            second_key_list.append(i[1])
+                        first_set = set(first_key_list)    
+                        second_set = set(second_key_list)
+                        
                         s_first_set = sorted(first_set)
                         s_second_set = sorted(second_set)
                         m = len(first_set)

--- a/kipet/validation/test_problems/case51a/pyomo/fe_factory_example.py
+++ b/kipet/validation/test_problems/case51a/pyomo/fe_factory_example.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     optimizer = ParameterEstimator(pyomo_model2)
 
     optimizer.apply_discretization('dae.collocation',nfe=30,ncp=3,scheme='LAGRANGE-RADAU')
-    optimizer.model.time.pprint()
+    # optimizer.model.time.pprint()
 
     # Provide good initial guess
     p_guess = {'k1':2.0, 'k2':0.5}


### PR DESCRIPTION
1. Fix bugs in KIPET when using Pyomo 5.6.8
2. Fix a bug in validation file
3. Updated KIPET should work in Pyomo 5.6."9" and before
## Tests passed on Pyomo 5.6.9, 5.6.8, 5.6.6, 5.6.1